### PR TITLE
fix: shorten ICLOUDSTORAGE_PREFIX

### DIFF
--- a/iCloudStorage.m
+++ b/iCloudStorage.m
@@ -10,7 +10,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 
-static NSString* const ICLOUDSTORAGE_PREFIX = @"@com.exodusmovement.exodus.iCloudStorage/";
+static NSString* const ICLOUDSTORAGE_PREFIX = @"@com.exodus/";
 static NSString* const ICLOUD_STORE_CHANGED = @"ICLOUD_STORE_CHANGED";
 static NSString* const kStoreChangedEvent = @"iCloudStoreDidChangeRemotely";
 static NSString* const kChangedKeys = @"changedKeys";


### PR DESCRIPTION
Fix

<img width="643" alt="image" src="https://user-images.githubusercontent.com/377544/115845718-b91f2900-a453-11eb-83c0-ac1a7e42bed5.png">


> The maximum length for key strings for the iCloud key-value store is 64 bytes using UTF8 encoding. Attempting to write a value to a longer key name results in a runtime error.

The [doc](https://developer.apple.com/documentation/foundation/nsubiquitouskeyvaluestore) says we can use up to 64 chars as key name.

Not sure why need a prefix, there's no mention in the doc says the key must be unique across all apps. (global)